### PR TITLE
Silently check that the second branch exists

### DIFF
--- a/git-d8ci
+++ b/git-d8ci
@@ -21,8 +21,10 @@ test -z $second_branch && echo "Other branch to commit to required." 1>&2 && exi
 message=$2
 test -z "$message" && echo "Commit message required." 1>&2 && exit 1
 
-# Check econd branch exists
-git rev-parse --verify $second_branch
+# Check second branch exists
+if ! git rev-parse --verify $second_branch >/dev/null 2>&1; then
+  echo "git branch $second_branch not found." && exit 1
+fi
 
 first_branch=`git rev-parse --abbrev-ref HEAD`
 


### PR DESCRIPTION
Also provides a better error message than git's `fatal: Needed a single revision`

Edit: to provide a bit more background `git rev-parse` will exit with 0 if the rev was found. It seems to exit with 128 if the rev is not found.