### PR TITLE
Put dependencies in the logical order

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,16 @@ _How do I, as a developer, start working on the project?_
 
 This project depends on:
 
-1. Drupal 8
-1. [composer](https://getcomposer.org/download/)
-1. [Node.js](https://nodejs.org/en/download/)
 1. [Homebrew](http://brew.sh/)
+1. [git] (https://git-scm.com/downloads)
+1. [composer](https://getcomposer.org/download/)
+1. Drupal 8
+1. [Node.js](https://nodejs.org/en/download/)
+1. [eslint](http://eslint.org/docs/user-guide/getting-started)
+    - Troubleshooting: Run `sudo npm update -g`
 1. pbcopy & pbpaste (yep because I use OS X)
 1. cowsay (```brew install cowsay```)
 1. [phpcs](http://pear.php.net/package/PHP_CodeSniffer/) and [Coder](https://www.drupal.org/project/coder) - see https://www.drupal.org/node/1419988 for instructions.
-1. [eslint](http://eslint.org/docs/user-guide/getting-started)
 1. [phpunit](https://phpunit.de/getting-started.html)
 
 


### PR DESCRIPTION
Homebrew can install git and composer, which in turn can be used to install D8, and node, which can in turn be used to install eslint.