### PR TITLE
Add PostCSS support

### DIFF
--- a/pre-commit-8-4
+++ b/pre-commit-8-4
@@ -131,7 +131,7 @@ for FILE in $FILES; do
         else
           # If there is no .es6.js file then there should be unless the .js is
           # not really Drupal's.
-          if ! [[ "$FILE" =~ ^core/assets/vendor ]] && ! [[ "$FILE" =~ ^core/scripts/js ]] && ! [[ -f "$TOP_LEVEL/$BASENAME.es6.js" ]]; then
+          if ! [[ "$FILE" =~ ^core/assets/vendor ]] && ! [[ "$FILE" =~ ^core/scripts/js ]] && ! [[ "$FILE" =~ ^core/scripts/css ]] && ! [[ "$FILE" =~ core/postcss.config.js ]] && ! [[ -f "$TOP_LEVEL/$BASENAME.es6.js" ]]; then
             echo -e "${red}FAILURE${reset} $FILE does not have a corresponding $BASENAME.es6.js"
             STATUS=1
           fi

--- a/pre-commit-8-4
+++ b/pre-commit-8-4
@@ -156,6 +156,39 @@ for FILE in $FILES; do
     ############################################################################
     ### CSS FILES
     ############################################################################
+    if [[ -f "$TOP_LEVEL/$FILE" ]] && [[ $FILE =~ \.css$ ]] ; then
+     # Work out the root name of the CSS so we can ensure that the PostCSS
+     # version has been compiled correctly.
+     if [[ $FILE =~ \.pcss\.css$ ]] ; then
+       BASENAME=${FILE%.pcss.css}
+       COMPILE_CHECK=1
+     else
+       BASENAME=${FILE%.css}
+       # We only need to compile check if the .pcss.css file is not also
+       # changing. This is because the compile check will occur for the
+       # .pcss.css file. This might occur if the compiled stylesheets have
+       # changed.
+       contains_element "$BASENAME.pcss.css" "${FILES[@]}"
+       HASPOSTCSS=$?
+       if [ "$HASPOSTCSS" -ne "0" ] ; then
+         COMPILE_CHECK=1
+       else
+         COMPILE_CHECK=0
+       fi
+     fi
+     # PostCSS
+     if [[ "$COMPILE_CHECK" == "1" ]] && [[ -f "$TOP_LEVEL/$BASENAME.pcss.css" ]] ; then
+       cd "$TOP_LEVEL/core"
+       yarn run build:css -- --check --file "$TOP_LEVEL/$BASENAME.pcss.css"
+       CORRECTCSS=$?
+       if [ "$CORRECTCSS" -ne "0" ] ; then
+         # No need to write any output the yarn run command will do this for
+         # us.
+         STATUS=1
+       fi
+       cd $TOP_LEVEL
+     fi
+   fi
     if [[ -f "$TOP_LEVEL/$FILE" ]] && [[ $FILE =~ \.css$ ]] && [[ -f "core/node_modules/.bin/stylelint" ]] ; then
       core/node_modules/.bin/stylelint "$FILE"
       if [ "$?" -ne "0" ] ; then


### PR DESCRIPTION
See https://www.drupal.org/project/drupal/issues/3060153#comment-13285447 + https://www.drupal.org/project/drupal/issues/3060153#comment-13285492

Once Claro lands, we should consider *requiring* `*.pcss.css` files for all CSS files in `core/themes/claro`, much like https://github.com/alexpott/d8githooks/commit/a45a1752c04959356bdf2e5c2bd438b58611f20c. But instead of core-wide, only for Claro.