### PR TITLE
Skip linting on generated CSS files

### DIFF
--- a/pre-commit-8-4
+++ b/pre-commit-8-4
@@ -197,15 +197,16 @@ for FILE in $FILES; do
           STATUS=1
         fi
         cd $TOP_LEVEL
-      fi
-    fi
-    if [[ -f "$TOP_LEVEL/$FILE" ]] && [[ $FILE =~ \.css$ ]] && [[ -f "core/node_modules/.bin/stylelint" ]] ; then
-      core/node_modules/.bin/stylelint "$FILE"
-      if [ "$?" -ne "0" ] ; then
-        STATUS=1
-        else
+      else
+        if [[ -f "$TOP_LEVEL/$FILE" ]] && [[ $FILE =~ \.css$ ]] && [[ -f "core/node_modules/.bin/stylelint" ]] ; then
+          core/node_modules/.bin/stylelint "$FILE"
+          if [ "$?" -ne "0" ] ; then
+            STATUS=1
+          else
             echo -e "STYLELINT: $FILE ${green}passed${reset}"
+          fi
         fi
+      fi
     fi
 
 done

--- a/pre-commit-8-4
+++ b/pre-commit-8-4
@@ -196,8 +196,16 @@ for FILE in $FILES; do
           # us.
           STATUS=1
         fi
+        # Lint the .pcss.css file.
+        node_modules/.bin/stylelint "$TOP_LEVEL/$BASENAME.pcss.css"
+        if [ "$?" -ne "0" ] ; then
+          STATUS=1
+        else
+          echo -e "STYLELINT: $BASENAME.pcss.css ${green}passed${reset}"
+        fi
         cd $TOP_LEVEL
       else
+        # Lint .css files that are not PostCSS generated.
         if [[ -f "$TOP_LEVEL/$FILE" ]] && [[ $FILE =~ \.css$ ]] && [[ -f "core/node_modules/.bin/stylelint" ]] ; then
           core/node_modules/.bin/stylelint "$FILE"
           if [ "$?" -ne "0" ] ; then


### PR DESCRIPTION
We should skip linting on generated CSS files. This is in line with the .stylelintignore file that is being added as part of https://www.drupal.org/project/drupal/issues/3079738.