### PR TITLE
Add check for jQuery UI source (#28)

### DIFF
--- a/pre-commit-8-4
+++ b/pre-commit-8-4
@@ -14,7 +14,7 @@ command_exists () {
 # Function to search array.
 contains_element () {
   local e
-  for e in "${@:2}"; do [[ "$e" == "$1" ]] && return 0; done
+  for e in ${@:2}; do [[ "$e" == "$1" ]] && return 0; done
   return 1
 }
 # Set up variables to make coloured output simple.
@@ -90,7 +90,7 @@ for FILE in $FILES; do
     ############################################################################
     ### JAVASCRIPT FILES
     ############################################################################
-    if [[ -f "$TOP_LEVEL/$FILE" ]] && [[ $FILE =~ \.js$ ]] && [[ ! $FILE =~ ^core/tests/Drupal/Nightwatch ]] ; then
+    if [[ -f "$TOP_LEVEL/$FILE" ]] && [[ $FILE =~ \.js$ ]] && [[ ! $FILE =~ ^core/tests/Drupal/Nightwatch ]] && [[ ! $FILE =~ ^core/assets/vendor/jquery.ui/ui ]]; then
         # Work out the root name of the Javascript so we can ensure that the ES6
         # version has been compiled correctly.
         if [[ $FILE =~ \.es6\.js$ ]] ; then
@@ -136,6 +136,38 @@ for FILE in $FILES; do
             STATUS=1
           fi
         fi
+    elif [[ -f "$TOP_LEVEL/$FILE" ]] && [[ $FILE =~ \.js$ ]] && [[ $FILE =~ ^core/assets/vendor/jquery.ui/ui ]]; then
+      ## Check for minified file changes.
+      if [[ $FILE =~ -min\.js$ ]] ; then
+        BASENAME=${FILE%-min.js}
+        contains_element "$BASENAME.js" "${FILES[@]}"
+        HASSRC=$?
+        if [ "$HASSRC" -ne "0" ] ; then
+          COMPILE_CHECK=1
+        else
+          ## Source was also changed and will be checked.
+          COMPILE_CHECK=0
+        fi
+      else
+        ## Check for source changes.
+        BASENAME=${FILE%.js}
+        COMPILE_CHECK=1
+      fi
+      if [[ "$COMPILE_CHECK" == "1" ]] && [[ -f "$TOP_LEVEL/$BASENAME.js" ]] ; then
+        cd "$TOP_LEVEL/core"
+        yarn run build:jqueryui --check --file "$TOP_LEVEL/$BASENAME.js"
+        CORRECTJS=$?
+        if [ "$CORRECTJS" -ne "0" ] ; then
+          # The yarn run command will write any error output.
+          STATUS=1
+        fi
+      else
+        # If there is no .js source file
+        if ! [[ -f "$TOP_LEVEL/$BASENAME.js" ]]; then
+          echo -e "${red}FAILURE${reset} $FILE does not have a corresponding $BASENAME.js"
+          STATUS=1
+        fi
+      fi
     else
       # Check coding standards of Nightwatch files.
       if [[ -f "$TOP_LEVEL/$FILE" ]] && [[ $FILE =~ \.js$ ]]; then


### PR DESCRIPTION
This adds a check for the source files in `core/assets/vendor/jquery.ui/ui` to ensure that both source and minified files match for #28 

The latest patch posted in comment 66 has the js for `yarn run build:jqueryui --check --file "$TOP_LEVEL/$BASENAME.js"`

https://www.drupal.org/project/drupal/issues/3087685#comment-13363277


