### PR TITLE
Return back to root folder after file check

### DIFF
--- a/pre-commit-8-4
+++ b/pre-commit-8-4
@@ -161,6 +161,7 @@ for FILE in $FILES; do
           # The yarn run command will write any error output.
           STATUS=1
         fi
+        cd $TOP_LEVEL
       else
         # If there is no .js source file
         if ! [[ -f "$TOP_LEVEL/$BASENAME.js" ]]; then


### PR DESCRIPTION
I was getting the following error when testing this with https://www.drupal.org/project/drupal/issues/3087685#comment-13363277:

```
/Users/lauri.eskola/Projects/d8githooks/pre-commit-8-4: line 79: vendor/bin/phpcs: No such file or directory
/Users/lauri.eskola/Projects/d8githooks/pre-commit-8-4: line 79: vendor/bin/phpcs: No such file or directory
```

It seems like this is because the hooks try to run `vendor/bin/phpcs` in the `./core` folder.