### PR TITLE
git-d8ci uses bashisms, so run it with bash.

### DIFF
--- a/git-d8ci
+++ b/git-d8ci
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Instructions for set up:
 # 1. Put this in a file named git-d8ci in your $PATH


### PR DESCRIPTION
On Linux `sh` is different to `bash`, the script doesn't run properly for me without this.